### PR TITLE
fix: fixed cart view styles not applying on initial load and refresh in prod

### DIFF
--- a/src/components/layout/layout.jsx
+++ b/src/components/layout/layout.jsx
@@ -23,10 +23,12 @@ const Layout = ({ location, children }) => {
 
   return (
     <div className={cartView ? styles.noscroll : null}>
-      <CartView />
-      <Blur />
-      <NavBar isCheckout={isCheckout} />
-      <main>{children}</main>
+      <main>
+        <CartView />
+        <Blur />
+        <NavBar isCheckout={isCheckout} />
+        {children}
+      </main>
     </div>
   );
 };


### PR DESCRIPTION
Fixed cart view styles not applying on initial loads and on subsequent hard refreshes.