### PR TITLE
Update StoreProvider in case of null cartId

### DIFF
--- a/src/context/store-context.js
+++ b/src/context/store-context.js
@@ -74,7 +74,7 @@ export const StoreProvider = ({ children }) => {
         dispatch({ type: "setCart", payload: data.cart });
       });
     } else {
-      client.carts.create(cartId).then((data) => {
+      client.carts.create().then((data) => {
         dispatch({ type: "setCart", payload: data.cart });
         if (localStorage) {
           localStorage.setItem("cart_id", data.cart.id);


### PR DESCRIPTION
Passing null to create() function crashes the starter app, works as expected when passing undefined value.